### PR TITLE
Allow the user to use custom shapes and enable/disable the border

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 out/
 .webpack
+.idea

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ After running for the first time you can access the app settings through the tra
       <td>Toggle rounded camera (window must be focused)</td>
     </tr>
     <tr>
+      <td>p</td>
+      <td>Toggle <a href="#using-custom-shapes">custom shapes</a> (window must be focused)</td>
+    </tr>
+    <tr>
       <td>r</td>
       <td>Reset zoom (window must be focused)</td>
     </tr>
@@ -104,7 +108,14 @@ After running for the first time you can access the app settings through the tra
   </tbody>
 </table>
 
+
 > On macOS you can use Command instead of Ctrl.
+
+## Using custom shapes
+
+You can use custom shapes using the [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path)
+CSS property. You can use a tool like [Clippy](https://bennettfeely.com/clippy/) to play around with different shapes
+you can build with `clip-path`.
 
 ## Author
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -77,7 +77,7 @@ const userPreferencesSchema: Schema<unknown> = {
   zoom: {
     type: JSONSchemaType.Number,
   },
-  borderColorCss: {
+  borderColor: {
     type: JSONSchemaType.String,
   },
   showBorder: {
@@ -119,7 +119,7 @@ export const userPreferences = new Store({
     clipPath: '',
     flipHorizontal: false,
     zoom: 1.1,
-    borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',
+    borderColor: 'linear-gradient(to right, #988BC7, #FF79C6)',
     showBorder: true,
     filter: '',
   },

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -83,9 +83,6 @@ const userPreferencesSchema: Schema<unknown> = {
   showBorder: {
     type: JSONSchemaType.Boolean,
   },
-  filter: {
-    type: JSONSchemaType.String,
-  },
 }
 
 export const userPreferences = new Store({
@@ -121,7 +118,6 @@ export const userPreferences = new Store({
     zoom: 1.1,
     borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',
     showBorder: true,
-    filter: '',
   },
 })
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -83,6 +83,9 @@ const userPreferencesSchema: Schema<unknown> = {
   showBorder: {
     type: JSONSchemaType.Boolean,
   },
+  filter: {
+    type: JSONSchemaType.String,
+  },
 }
 
 export const userPreferences = new Store({
@@ -118,6 +121,7 @@ export const userPreferences = new Store({
     zoom: 1.1,
     borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',
     showBorder: true,
+    filter: '',
   },
 })
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -68,6 +68,9 @@ const userPreferencesSchema: Schema<unknown> = {
   rounded: {
     type: JSONSchemaType.Boolean,
   },
+  clipPath: {
+    type: JSONSchemaType.String,
+  },
   flipHorizontal: {
     type: JSONSchemaType.Boolean,
   },
@@ -110,6 +113,7 @@ export const userPreferences = new Store({
       hideCamera: 'Shift+Alt+CommandOrControl+3',
     },
     rounded: true,
+    clipPath: '',
     flipHorizontal: false,
     zoom: 1.1,
     borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -77,6 +77,9 @@ const userPreferencesSchema: Schema<unknown> = {
   borderColorCss: {
     type: JSONSchemaType.String,
   },
+  showBorder: {
+    type: JSONSchemaType.Boolean,
+  },
 }
 
 export const userPreferences = new Store({
@@ -110,6 +113,7 @@ export const userPreferences = new Store({
     flipHorizontal: false,
     zoom: 1.1,
     borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',
+    showBorder: true,
   },
 })
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -77,7 +77,7 @@ const userPreferencesSchema: Schema<unknown> = {
   zoom: {
     type: JSONSchemaType.Number,
   },
-  borderColor: {
+  borderColorCss: {
     type: JSONSchemaType.String,
   },
   showBorder: {
@@ -119,7 +119,7 @@ export const userPreferences = new Store({
     clipPath: '',
     flipHorizontal: false,
     zoom: 1.1,
-    borderColor: 'linear-gradient(to right, #988BC7, #FF79C6)',
+    borderColorCss: 'linear-gradient(to right, #988BC7, #FF79C6)',
     showBorder: true,
     filter: '',
   },

--- a/public/index.html
+++ b/public/index.html
@@ -91,10 +91,7 @@
       border-radius: 9999px;
     }
 
-    #wrapper.has-clip-path:before {
-      clip-path: var(--clip-path);
-    }
-
+    #wrapper.has-clip-path:before,
     #wrapper.has-clip-path .video-wrapper {
       clip-path: var(--clip-path);
     }

--- a/public/index.html
+++ b/public/index.html
@@ -83,10 +83,7 @@
       height: calc(100vw - 1px);
     }
 
-    #wrapper.rounded .video-wrapper {
-      border-radius: 9999px;
-    }
-
+    #wrapper.rounded .video-wrapper,
     #wrapper.rounded video {
       border-radius: 9999px;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -77,15 +77,10 @@
       background: var(--border-color);
     }
 
-    #wrapper.rounded {
-      border-radius: 50%;
-      /* fix border-radius on Mac Mojave */
-      height: calc(100vw - 1px);
-    }
-
+    #wrapper.rounded,
     #wrapper.rounded .video-wrapper,
     #wrapper.rounded video {
-      border-radius: 9999px;
+      clip-path: circle(50% at 50% 50%);
     }
 
     #wrapper.has-clip-path:before,

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,6 @@
 
     video {
       height: 100vh;
-      border-radius: 9999px;
       pointer-events: none;
       background: #121214;
     }
@@ -50,8 +49,6 @@
       color: #FFF;
       background: transparent;
       background-clip: padding-box;
-      border: solid 5px transparent;
-      border-radius: 16px;
     }
 
     #wrapper:before {
@@ -61,7 +58,6 @@
       z-index: -1;
       margin: -5px;
       border-radius: inherit;
-      background: var(--border-color);
     }
 
     .video-wrapper {
@@ -69,8 +65,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 16px;
       background: transparent;
+    }
+
+    #wrapper.has-border {
+      border: solid 5px transparent;
+    }
+
+    #wrapper.has-border:before {
+      background: var(--border-color);
     }
 
     #wrapper.rounded {
@@ -80,6 +83,10 @@
     }
 
     #wrapper.rounded .video-wrapper {
+      border-radius: 9999px;
+    }
+
+    #wrapper.rounded video {
       border-radius: 9999px;
     }
   </style>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
   <style>
     :root {
       --border-color: linear-gradient(to right, #988BC7, #FF79C6);
+      --clip-path: inherit;
     }
 
     body, #video-grid {
@@ -88,6 +89,14 @@
 
     #wrapper.rounded video {
       border-radius: 9999px;
+    }
+
+    #wrapper.has-clip-path:before {
+      clip-path: var(--clip-path);
+    }
+
+    #wrapper.has-clip-path .video-wrapper {
+      clip-path: var(--clip-path);
     }
   </style>
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,7 +13,8 @@
       --clip-path: inherit;
     }
 
-    body, #video-grid {
+    body,
+    #video-grid {
       -webkit-app-region: drag;
     }
 
@@ -30,10 +32,6 @@
       height: 100vh;
       pointer-events: none;
       background: #121214;
-    }
-
-    .flip {
-      transform: rotateY(180deg);
     }
 
     #wrapper {
@@ -55,7 +53,10 @@
     #wrapper:before {
       content: '';
       position: absolute;
-      top: 0; right: 0; bottom: 0; left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
       z-index: -1;
       margin: -5px;
       border-radius: inherit;
@@ -93,6 +94,7 @@
     const global = globalThis;
   </script>
 </head>
+
 <body>
   <div id="wrapper">
     <div class="video-wrapper">
@@ -100,4 +102,5 @@
     </div>
   </div>
 </body>
+
 </html>

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -81,8 +81,8 @@ export class CameraController {
   }
 
   private applyBorder() {
-    if (config.borderColorCss) {
-      this.root.style.setProperty('--border-color', config.borderColorCss)
+    if (config.borderColor) {
+      this.root.style.setProperty('--border-color', config.borderColor)
     }
 
     if (config.showBorder) {

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -10,6 +10,7 @@ export class CameraController {
   private wrapperElement: HTMLDivElement
   private isFlipped: boolean
   private isRounded: boolean
+  private isClipped: boolean
   private position: Record<'x' | 'y' | 'z', number>
   private root: HTMLElement
 
@@ -20,6 +21,7 @@ export class CameraController {
 
     this.isFlipped = config.flipHorizontal
     this.isRounded = config.rounded
+    this.isClipped = !!config.clipPath
 
     this.position = {
       x: config.horizontal,
@@ -75,6 +77,12 @@ export class CameraController {
     this.render()
   }
 
+  public clip() {
+    this.isClipped = !this.isClipped
+
+    this.render()
+  }
+
   private applyPositioning() {
     this.videoElement.style.transform = `translate(${this.position.x}%, ${this.position.y}%) scale(${this.position.z})`
 
@@ -95,15 +103,17 @@ export class CameraController {
   }
 
   private applyShape() {
-    if (!config.clipPath && this.isRounded) {
+    if (this.isRounded) {
       this.wrapperElement.classList.add('rounded')
     } else {
       this.wrapperElement.classList.remove('rounded')
     }
 
-    if (config.clipPath) {
+    if (this.isClipped && config.clipPath) {
       this.wrapperElement.classList.add('has-clip-path')
       this.root.style.setProperty('--clip-path', config.clipPath)
+    } else {
+      this.wrapperElement.classList.remove('has-clip-path')
     }
   }
 

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -7,14 +7,14 @@ type ZoomType = 'in' | 'out'
 export class CameraController {
   public videoElement: HTMLVideoElement
 
-  private videoWrapper: HTMLDivElement
+  private wrapperElement: HTMLDivElement
   private isFlipped: boolean
   private isRounded: boolean
   private position: Record<'x' | 'y' | 'z', number>
   private root: HTMLElement
 
   constructor() {
-    this.videoWrapper = document.getElementById('wrapper') as HTMLDivElement
+    this.wrapperElement = document.getElementById('wrapper') as HTMLDivElement
     this.videoElement = document.getElementById('video') as HTMLVideoElement
     this.root = document.querySelector(':root') as HTMLElement
 
@@ -71,24 +71,34 @@ export class CameraController {
     this.render()
   }
 
-  private render() {
-    const transform: string[] = []
-    const classList: string[] = []
-
-    transform.push(`translate(${this.position.x}%, ${this.position.y}%)`)
-    transform.push(`scale(${this.position.z})`)
+  private applyPositioning() {
+    this.videoElement.style.transform = `translate(${this.position.x}%, ${this.position.y}%) scale(${this.position.z})`
 
     if (this.isFlipped) {
-      classList.push('flip')
-      transform.push('rotateY(180deg)')
+      this.videoElement.style.transform += 'rotateY(180deg)'
+      this.videoElement.classList.add('flip')
     }
+  }
 
-    this.videoElement.style.transform = transform.join(' ')
-    this.videoElement.className = classList.join(' ')
-    this.videoWrapper.className = this.isRounded ? 'rounded' : ''
-
+  private applyBorder() {
     if (config.borderColorCss) {
       this.root.style.setProperty('--border-color', config.borderColorCss)
     }
+
+    if (config.showBorder) {
+      this.wrapperElement.classList.add('has-border')
+    }
+  }
+
+  private applyShape() {
+    if (this.isRounded) {
+      this.wrapperElement.classList.add('rounded')
+    }
+  }
+
+  private render() {
+    this.applyPositioning()
+    this.applyBorder()
+    this.applyShape()
   }
 }

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -117,16 +117,9 @@ export class CameraController {
     }
   }
 
-  private applyFilter() {
-    if (config.filter) {
-      this.videoElement.style.setProperty('filter', config.filter)
-    }
-  }
-
   private render() {
     this.applyPositioning()
     this.applyBorder()
     this.applyShape()
-    this.applyFilter()
   }
 }

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -93,8 +93,8 @@ export class CameraController {
   }
 
   private applyBorder() {
-    if (config.borderColor) {
-      this.root.style.setProperty('--border-color', config.borderColor)
+    if (config.borderColorCss) {
+      this.root.style.setProperty('--border-color', config.borderColorCss)
     }
 
     if (config.showBorder) {

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -88,7 +88,6 @@ export class CameraController {
 
     if (this.isFlipped) {
       this.videoElement.style.transform += 'rotateY(180deg)'
-      this.videoElement.classList.add('flip')
     }
   }
 

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -93,6 +93,8 @@ export class CameraController {
   private applyShape() {
     if (!config.clipPath && this.isRounded) {
       this.wrapperElement.classList.add('rounded')
+    } else {
+      this.wrapperElement.classList.remove('rounded')
     }
 
     if (config.clipPath) {

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -96,7 +96,8 @@ export class CameraController {
     }
 
     if (config.clipPath) {
-      this.wrapperElement.style.setProperty('clip-path', config.clipPath)
+      this.wrapperElement.classList.add('has-clip-path')
+      this.root.style.setProperty('--clip-path', config.clipPath)
     }
   }
 

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -91,8 +91,12 @@ export class CameraController {
   }
 
   private applyShape() {
-    if (this.isRounded) {
+    if (!config.clipPath && this.isRounded) {
       this.wrapperElement.classList.add('rounded')
+    }
+
+    if (config.clipPath) {
+      this.wrapperElement.style.setProperty('clip-path', config.clipPath)
     }
   }
 

--- a/src/cam.ts
+++ b/src/cam.ts
@@ -100,9 +100,16 @@ export class CameraController {
     }
   }
 
+  private applyFilter() {
+    if (config.filter) {
+      this.videoElement.style.setProperty('filter', config.filter)
+    }
+  }
+
   private render() {
     this.applyPositioning()
     this.applyBorder()
     this.applyShape()
+    this.applyFilter()
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ const config = {
   scale: Number(userPreferences.zoom ?? 1),
   horizontal: Number(userPreferences.anchor.x ?? 0),
   vertical: Number(userPreferences.anchor.y ?? 0),
-  borderColorCss: userPreferences.borderColorCss,
+  borderColor: userPreferences.borderColor,
   showBorder: userPreferences.showBorder,
   clipPath: userPreferences.clipPath,
   filter: userPreferences.filter,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,6 @@ const config = {
   borderColorCss: userPreferences.borderColorCss,
   showBorder: userPreferences.showBorder,
   clipPath: userPreferences.clipPath,
-  filter: userPreferences.filter,
 }
 
 export { config }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const config = {
   horizontal: Number(userPreferences.anchor.x ?? 0),
   vertical: Number(userPreferences.anchor.y ?? 0),
   borderColorCss: userPreferences.borderColorCss,
+  showBorder: userPreferences.showBorder,
 }
 
 export { config }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ const config = {
   scale: Number(userPreferences.zoom ?? 1),
   horizontal: Number(userPreferences.anchor.x ?? 0),
   vertical: Number(userPreferences.anchor.y ?? 0),
-  borderColor: userPreferences.borderColor,
+  borderColorCss: userPreferences.borderColorCss,
   showBorder: userPreferences.showBorder,
   clipPath: userPreferences.clipPath,
   filter: userPreferences.filter,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const config = {
   borderColorCss: userPreferences.borderColorCss,
   showBorder: userPreferences.showBorder,
   clipPath: userPreferences.clipPath,
+  filter: userPreferences.filter,
 }
 
 export { config }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const config = {
   vertical: Number(userPreferences.anchor.y ?? 0),
   borderColorCss: userPreferences.borderColorCss,
   showBorder: userPreferences.showBorder,
+  clipPath: userPreferences.clipPath,
 }
 
 export { config }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const controls = {
   ArrowUp: () => cameraController.adjustOffset('up'),
   ArrowDown: () => cameraController.adjustOffset('down'),
   o: () => cameraController.round(),
+  p: () => cameraController.clip(),
   r: () => cameraController.reset(),
   '=': () => cameraController.zoom('in'),
   '-': () => cameraController.zoom('out'),


### PR DESCRIPTION
Changes:

- [x] <strike>Add support to CSS filters;</strike>
- [x] Add support to custom shapes with CSS `clip-path`<sup><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path" title="See documentation on MDN">1</a></sup>. <strike>When a `clip-path` is defined, the rounded setting is ignored</strike>;
- [x] Add option to enable/disable border;
- [x] Reorganizes the CSS for better readability;
- [x] Refactor render method to allow future extensions.