### PR TITLE
feat: add release cli helper

### DIFF
--- a/bin/constants/colors.js
+++ b/bin/constants/colors.js
@@ -1,0 +1,13 @@
+exports.COLORS = {
+  RED: '\x1b[31m',
+  RESET: '\x1b[0m',
+  GRAY: '\x1b[90m',
+  BLUE: '\x1b[34m',
+  CYAN: '\x1b[36m',
+  GREEN: '\x1b[32m',
+  WHITE: '\x1b[37m',
+  YELLOW: '\x1b[33m',
+  MAGENTA: '\x1b[35m',
+  LIGHT_GRAY: '\x1b[37m',
+  SOFT_GRAY: '\x1b[38;5;244m',
+}

--- a/bin/constants/index.js
+++ b/bin/constants/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('./colors'),
+}

--- a/bin/modules/release/index.js
+++ b/bin/modules/release/index.js
@@ -1,0 +1,75 @@
+const { writeFile } = require('fs/promises')
+const { resolve } = require('path')
+const open = require('open')
+
+const { extractOwnerAndRepoFromGitRemoteURL } = require('./utils')
+const { checkValidations } = require('./validations')
+const packageJSON = require('../../../package.json')
+const { question, exec } = require('../../utils')
+const { COLORS } = require('../../constants')
+
+async function makeRelease() {
+  console.clear()
+
+  const { version } = packageJSON
+
+  const newVersion = await question(
+    `Enter a new version: ${COLORS.SOFT_GRAY}(current is ${version})${COLORS.RESET} `
+  )
+
+  if (checkValidations({ version, newVersion })) {
+    return
+  }
+
+  packageJSON.version = newVersion
+
+  try {
+    console.log(
+      `${COLORS.CYAN}> Updating package.json version...${COLORS.RESET}`
+    )
+
+    await writeFile(
+      resolve('package.json'),
+      JSON.stringify(packageJSON, null, 2)
+    )
+
+    console.log(`\n${COLORS.GREEN}Done!${COLORS.RESET}\n`)
+    console.log(`${COLORS.CYAN}> Trying to release it...${COLORS.RESET}`)
+
+    exec(
+      [
+        `git commit -am v${newVersion}`,
+        `git tag v${newVersion}`,
+        `git push`,
+        `git push --tags`,
+      ],
+      {
+        inherit: true,
+      }
+    )
+
+    const [repository] = exec([`git remote get-url --push origin`])
+    const ownerAndRepo = extractOwnerAndRepoFromGitRemoteURL(repository)
+
+    console.log(
+      `${COLORS.CYAN}> Opening to repo releases page...${COLORS.RESET}`
+    )
+
+    await open(`https://github.com/${ownerAndRepo}/releases`)
+
+    console.log(
+      `${COLORS.CYAN}> Opening to repo actions page...${COLORS.RESET}`
+    )
+
+    await open(`https://github.com/${ownerAndRepo}/actions`)
+
+    console.log(`\n${COLORS.GREEN}Done!${COLORS.RESET}\n`)
+  } catch ({ message }) {
+    console.log(`
+    🛑 Something went wrong!\n
+      👀 Error: ${message}
+    `)
+  }
+}
+
+makeRelease()

--- a/bin/modules/release/utils/extractors.js
+++ b/bin/modules/release/utils/extractors.js
@@ -1,0 +1,3 @@
+exports.extractOwnerAndRepoFromGitRemoteURL = url => {
+  return url?.replace(/^git@github.com:|.git$/gims, '').trim()
+}

--- a/bin/modules/release/utils/index.js
+++ b/bin/modules/release/utils/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('./extractors'),
+}

--- a/bin/modules/release/validations/index.js
+++ b/bin/modules/release/validations/index.js
@@ -1,0 +1,35 @@
+const semver = require('semver')
+
+const { COLORS } = require('../../../constants')
+
+exports.checkValidations = ({ version, newVersion }) => {
+  if (!newVersion) {
+    console.log(`${COLORS.RED}No version entered${COLORS.RESET}`)
+
+    return true
+  }
+
+  if (!semver.valid(newVersion)) {
+    console.log(
+      `${COLORS.RED}Version must have a semver format (${COLORS.SOFT_GRAY}x.x.x${COLORS.RESET} example: ${COLORS.GREEN}1.0.1${COLORS.RESET}${COLORS.RED})${COLORS.RESET}`
+    )
+
+    return true
+  }
+
+  if (semver.ltr(newVersion, version)) {
+    console.log(
+      `${COLORS.RED}New version is lower than current version${COLORS.RESET}`
+    )
+
+    return true
+  }
+
+  if (semver.eq(newVersion, version)) {
+    console.log(
+      `${COLORS.RED}New version is equal to current version${COLORS.RESET}`
+    )
+
+    return true
+  }
+}

--- a/bin/utils/exec.js
+++ b/bin/utils/exec.js
@@ -1,0 +1,21 @@
+const { execSync } = require('child_process')
+const { resolve } = require('path')
+
+function makeOptions(options) {
+  return {
+    stdio: options?.inherit ? 'inherit' : 'pipe',
+    cwd: resolve(),
+    encoding: 'utf8',
+  }
+}
+
+exports.exec = (commands, options) => {
+  const outputs = []
+
+  for (const command of commands) {
+    const output = execSync(command, makeOptions(options))
+    outputs.push(output)
+  }
+
+  return outputs
+}

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('./question'),
+  ...require('./exec'),
+}

--- a/bin/utils/question.js
+++ b/bin/utils/question.js
@@ -1,0 +1,15 @@
+const Readline = require('readline')
+
+exports.question = question => {
+  const readline = Readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise(resolve => {
+    readline.question(question, answer => {
+      readline.close()
+      resolve(answer)
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
+    "make:release": "node ./bin/modules/release/index.js",
     "dist": "electron-builder",
     "release": "electron-builder --publish always",
     "postinstall": "npm-run-all package install:deps",


### PR DESCRIPTION
I made a CLI helper to make the release process better in my [Electron App Boilerplate](https://github.com/daltonmenezes/electron-app), so I'm bringing it here too.

This PR:
- Adds a CLI helper to make the releases intuitively by performing `yarn make:release`
## Preview
https://user-images.githubusercontent.com/1149845/156939675-5ea0c510-ddd3-4de7-b293-87d3697bd1a8.mp4