### PR TITLE
feat: add permanent storage for deviceId

### DIFF
--- a/src/renderer/bridge/ipcs/devices/send.ts
+++ b/src/renderer/bridge/ipcs/devices/send.ts
@@ -12,5 +12,9 @@ export function sendVideoInputDeviceList(devices: VideoDevice[]) {
 export function sendActiveVideoInputId(id: string) {
   const { GET_ACTIVE_VIDEO_INPUT_ID } = IPC.DEVICES
 
+  if (id) {
+    localStorage.setItem('deviceId', id)
+  }
+
   ipcRenderer.send(GET_ACTIVE_VIDEO_INPUT_ID, id)
 }

--- a/src/renderer/bridge/ipcs/devices/when/video-input-changes.ts
+++ b/src/renderer/bridge/ipcs/devices/when/video-input-changes.ts
@@ -6,6 +6,7 @@ export function whenVideoInputChanges(fn: (...args: any[]) => void) {
   const { WHEN_VIDEO_INPUT_CHANGES } = IPC.DEVICES
 
   ipcRenderer.on(WHEN_VIDEO_INPUT_CHANGES, (_, ...args) => {
+    localStorage.setItem('deviceId', args[0])
     fn(...args)
   })
 }

--- a/src/renderer/hooks/useLookForVideoInputDevices.ts
+++ b/src/renderer/hooks/useLookForVideoInputDevices.ts
@@ -14,7 +14,12 @@ export function useLookForVideoInputDevices({
     if (deviceId || !shouldLookForDevices) return
 
     isLookingForDevices = setInterval(() => {
-      const deviceId = videoInputDevicesRef.current[0]?.deviceId
+      const target = localStorage.getItem('deviceId')
+
+      const deviceId =
+        videoInputDevicesRef.current?.find(
+          (device) => device.deviceId === target
+        )?.deviceId ?? videoInputDevicesRef.current[0]?.deviceId
 
       callback()
 
@@ -23,7 +28,7 @@ export function useLookForVideoInputDevices({
         setShouldLookForDevices(false)
       }
 
-      setDeviceId(videoInputDevicesRef.current[0]?.deviceId)
+      setDeviceId(deviceId)
     }, 1000)
 
     return () => clearInterval(isLookingForDevices)


### PR DESCRIPTION
This PR adds permanent storage for the `deviceId`, so everytime you open the app again you will automatically use the device you were using by the time you closed the app.

Because it's simple and data can be more dynamic (e.g the device can be unavailable) it's using `localStorage` strategy to store the `deviceId` value every time its value changes (via `sendActiveVideoInputId` and `whenVideoInputChanges`).